### PR TITLE
Eliminates flag  at package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "test:unit": "vue-cli-service test:unit --watchAll",
+    "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
     "test:coverage": "jest --collectCoverage",
     "lint": "vue-cli-service lint"


### PR DESCRIPTION
Fix #26 
Eliminates  the flag `--watchAll`  from test unit scripts at package.json